### PR TITLE
Refactor

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -2,12 +2,11 @@ package mention
 
 import (
 	"fmt"
-	"strings"
 )
 
 func ExampleGetTags_mention() {
 	msg := " hello @gernest"
-	tags := GetTags('@', strings.NewReader(msg))
+	tags := GetTags('@', msg)
 	fmt.Println(tags)
 
 	//Output:
@@ -16,7 +15,7 @@ func ExampleGetTags_mention() {
 
 func ExampleGetTags_hashtag() {
 	msg := " viva la #tanzania"
-	tags := GetTags('#', strings.NewReader(msg))
+	tags := GetTags('#', msg)
 	fmt.Println(tags)
 
 	//Output:

--- a/mention_test.go
+++ b/mention_test.go
@@ -2,34 +2,35 @@ package mention
 
 import (
 	"reflect"
-	"strings"
 	"testing"
 )
 
-func TestGetTag(t *testing.T) {
+func TestGetTags(t *testing.T) {
+
 	sample := []struct {
 		src string
 		tag []string
 	}{
-		// {"@gernest", []string{"gernest"}},
-		// {"@gernest ", []string{"gernest"}},
-		{"@gernest@mwanza hello", []string{"gernest", "mwanza"}},
+		{"@gernest", []string{"gernest"}},
+		{"@gernest ", []string{"gernest"}},
+		{"@gernest@mwanza hello", []string{"gernest@mwanza"}},
 		{"@gernest @mwanza", []string{"gernest", "mwanza"}},
+		{"Hello to @gernest. Maybe we can do it together @mwanza", []string{"gernest", "mwanza"}},
 		{" @gernest @mwanza", []string{"gernest", "mwanza"}},
 		{" @gernest @mwanza ", []string{"gernest", "mwanza"}},
 		{" @gernest @mwanza @tanzania", []string{"gernest", "mwanza", "tanzania"}},
 		{" @gernest,@mwanza/Tanzania ", []string{"gernest", "mwanza"}},
 		{"how does it feel to be rejected? @ it is @loner tt ggg sjdsj dj @linker ", []string{"loner", "linker"}},
 		{"This @gernest is @@@@ @@@ @@ @ @,, @, @mwanza,", []string{"gernest", "mwanza"}},
+		{"hello@world", nil},
 	}
+	terms := []rune(",/. ")
 
-	terminators := []rune{',', '/', '@'}
 	for _, v := range sample {
-		tag := GetTags('@', strings.NewReader(v.src), terminators...)
+		tag := GetTags('@', v.src, terms...)
 		if !reflect.DeepEqual(v.tag, tag) {
 			t.Errorf("expected  %v got %v for %s", v.tag, tag, v.src)
 		}
 
 	}
-
 }


### PR DESCRIPTION
I was trying to solve that a url like "http://example.com/foo#bar" doesn't return any hashtags (ie "#bar") and found the source code really hard to follow. Lots of variables that aren't clear what value they hold, lots of indentations, etc.

So I refactored with a different approach that is simpler to follow and better commented. There are some behavior changes....

 1) the `GetTags` func now takes a string instead of `io.Reader`
 2) "@gernest@mwanza" not returns `[gernest@mwanza]` instead of `[gernest, mwanza]`
 3) Having your char also be a terminator results in not the behavior you want.

Some of this may be controversial, happy to have that discussion.